### PR TITLE
fix: added config files to be ignored

### DIFF
--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -25,6 +25,12 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'react', 'import'],
+  ignorePatterns: [
+    'metro.config.js',
+    'babel.config.js',
+    'jest.config.js',
+    'react-native.config.js',
+  ],
   rules: {
     indent: ['error', 2],
     'linebreak-style': ['error', 'unix'],


### PR DESCRIPTION
#### Description

ESLint was finding errors in the config file even though they were in the correct format. Just added them to be ignored as they probably will not be modified again.

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn ios/android`
