### PR TITLE
refactor: switch to randomized ids for language

### DIFF
--- a/packages/mobile/features/configure_workout/ConfigureWorkout.tsx
+++ b/packages/mobile/features/configure_workout/ConfigureWorkout.tsx
@@ -7,11 +7,9 @@ import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   startWorkout: {
-    id: 'app.configureWorkout.startButton',
     defaultMessage: 'Start Workout',
   },
   enterWorkoutName: {
-    id: 'app.configureWorkout.enterWorkoutName',
     defaultMessage: 'Enter workout name',
   },
 });

--- a/packages/mobile/features/login/Login.tsx
+++ b/packages/mobile/features/login/Login.tsx
@@ -9,19 +9,15 @@ import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   welcome: {
-    id: 'app.login.welcome',
     defaultMessage: 'Welcome',
   },
   email: {
-    id: 'app.login.email',
     defaultMessage: 'Email',
   },
   password: {
-    id: 'app.login.password',
     defaultMessage: 'Password',
   },
   login: {
-    id: 'app.login.loginText',
     defaultMessage: 'Login',
   },
 });

--- a/packages/mobile/features/profile/Profile.tsx
+++ b/packages/mobile/features/profile/Profile.tsx
@@ -7,7 +7,6 @@ import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   signOut: {
-    id: 'app.profile.signOut',
     defaultMessage: 'Sign Out',
   },
 });

--- a/packages/mobile/i18n/globalMessages.ts
+++ b/packages/mobile/i18n/globalMessages.ts
@@ -2,7 +2,6 @@ import { defineMessages } from 'react-intl';
 
 const globalMessages = defineMessages({
   idle: {
-    id: 'app.global.idle',
     defaultMessage: 'Idle',
   },
 });

--- a/packages/mobile/i18n/locale/en.json
+++ b/packages/mobile/i18n/locale/en.json
@@ -1,26 +1,26 @@
 {
-  "app.configureWorkout.enterWorkoutName": {
-    "defaultMessage": "Enter workout name"
-  },
-  "app.configureWorkout.startButton": {
-    "defaultMessage": "Start Workout"
-  },
-  "app.global.idle": {
-    "defaultMessage": "Idle"
-  },
-  "app.login.email": {
-    "defaultMessage": "Email"
-  },
-  "app.login.loginText": {
-    "defaultMessage": "Login"
-  },
-  "app.login.password": {
+  "5sg7KC": {
     "defaultMessage": "Password"
   },
-  "app.login.welcome": {
+  "AyGauy": {
+    "defaultMessage": "Login"
+  },
+  "F62y+K": {
+    "defaultMessage": "Sign Out"
+  },
+  "I46hZe": {
+    "defaultMessage": "Enter workout name"
+  },
+  "PwaN2o": {
     "defaultMessage": "Welcome"
   },
-  "app.profile.signOut": {
-    "defaultMessage": "Sign Out"
+  "nPKV9/": {
+    "defaultMessage": "Start Workout"
+  },
+  "sNY4nx": {
+    "defaultMessage": "Idle"
+  },
+  "sy+pv5": {
+    "defaultMessage": "Email"
   }
 }

--- a/packages/mobile/i18n/locale/es.json
+++ b/packages/mobile/i18n/locale/es.json
@@ -1,26 +1,26 @@
 {
-  "app.configureWorkout.enterWorkoutName": {
+  "I46hZe": {
     "defaultMessage": "Ingrese el nombre del entrenamiento"
   },
-  "app.configureWorkout.startButton": {
+  "nPKV9/": {
     "defaultMessage": "Empezar a Entrenar"
   },
-  "app.global.idle": {
+  "sNY4nx": {
     "defaultMessage": "Inactiva"
   },
-  "app.login.email": {
+  "sy+pv5": {
     "defaultMessage": "Correo electrónico"
   },
-  "app.login.loginText": {
+  "AyGauy": {
     "defaultMessage": "Acceso"
   },
-  "app.login.password": {
+  "5sg7KC": {
     "defaultMessage": "Contraseña"
   },
-  "app.login.welcome": {
+  "PwaN2o": {
     "defaultMessage": "Bienvenido"
   },
-  "app.profile.signOut": {
+  "F62y+K": {
     "defaultMessage": "Desconectar"
   }
 }


### PR DESCRIPTION
#### Description

The purpose of this PR is to switch from manually entering ids for each language object to automatically created randomized ids. This will create less conflicts in the future.

- Removed all manually created ids

#### Screenshot (if UI-related)

N/A

#### To-Dos

- [x] Successful build `yarn ios/android`
- [x] Translation keys `yarn i18n:extract`
